### PR TITLE
Replace deprecated/removed `File.exists?` alias

### DIFF
--- a/lib/ey_config.rb
+++ b/lib/ey_config.rb
@@ -24,7 +24,7 @@ module EY
       end
 
       def init
-        unless File.exists?(full_path)
+        unless File.exist?(full_path)
           err_msg = ""
           if detected_a_dev_environment?
             ey_config_local_usage
@@ -101,7 +101,7 @@ module EY
         config_paths.each do |config_path|
           possible_path = File.expand_path(config_path)
           possible_paths << possible_path
-          if File.exists?(possible_path)
+          if File.exist?(possible_path)
             return possible_path
           end
         end


### PR DESCRIPTION
The alias `File.exists?` was removed in Ruby 3.2:

* https://bugs.ruby-lang.org/issues/17391
* https://rubyreferences.github.io/rubychanges/3.2.html#removals

`File.exist?` has been in Ruby since at least 1.8: https://ruby-doc.org/core-1.8.6/File.html#method-c-exist-3F