### PR TITLE
GHI-6911 - Replaced deprecated/removed `File.exists?` method

### DIFF
--- a/lib/ey_config.rb
+++ b/lib/ey_config.rb
@@ -24,7 +24,7 @@ module EY
       end
 
       def init
-        unless File.exist?(full_path)
+        unless File.exist?(full_path) # AI-GEN - cursor
           err_msg = ""
           if detected_a_dev_environment?
             ey_config_local_usage
@@ -101,7 +101,7 @@ module EY
         config_paths.each do |config_path|
           possible_path = File.expand_path(config_path)
           possible_paths << possible_path
-          if File.exist?(possible_path)
+          if File.exist?(possible_path) # AI-GEN - cursor
             return possible_path
           end
         end

--- a/lib/ey_config.rb
+++ b/lib/ey_config.rb
@@ -24,7 +24,7 @@ module EY
       end
 
       def init
-        unless File.exists?(full_path)
+        unless File.exist?(full_path)
           err_msg = ""
           if detected_a_dev_environment?
             ey_config_local_usage
@@ -101,7 +101,7 @@ module EY
         config_paths.each do |config_path|
           possible_path = File.expand_path(config_path)
           possible_paths << possible_path
-          if File.exists?(possible_path)
+          if File.exist?(possible_path)
             return possible_path
           end
         end

--- a/lib/ey_config/version.rb
+++ b/lib/ey_config/version.rb
@@ -1,5 +1,5 @@
 module EY
   class Config
-    VERSION = "0.0.7"
+    VERSION = "0.0.8" # AI-GEN - cursor
   end
 end

--- a/spec/ey_config_local_spec.rb
+++ b/spec/ey_config_local_spec.rb
@@ -21,7 +21,7 @@ describe EY::Config::Local do
     end
 
     it 'should create ey_services_config_local.yml' do
-      expect(File.exist?(EY::Config::Local.config_path)).to be_truthy
+      expect(File.exist?(EY::Config::Local.config_path)).to be_truthy # AI-GEN - cursor
     end
 
     it 'should add the keys passed from the command line' do

--- a/spec/ey_config_local_spec.rb
+++ b/spec/ey_config_local_spec.rb
@@ -21,7 +21,7 @@ describe EY::Config::Local do
     end
 
     it 'should create ey_services_config_local.yml' do
-      File.exist?(EY::Config::Local.config_path).should be_true
+      expect(File.exist?(EY::Config::Local.config_path)).to be_truthy
     end
 
     it 'should add the keys passed from the command line' do


### PR DESCRIPTION
The fix for https://github.com/trilogy-group/eng-maintenance/issues/6911